### PR TITLE
打通整个pipeline的过程中又遇到了一个载入模型的问题.

### DIFF
--- a/mhyao_src/LanuchHoldOutTest.py
+++ b/mhyao_src/LanuchHoldOutTest.py
@@ -1,15 +1,16 @@
 import pdb
 from pathlib import Path
 from mhyao_src.GraphManager import ProcessedGraphManager
-from mhyao_src.Experiments import PRATrain
+from mhyao_src.Experiments import PRATrain, Validation, Test
 
 
 if __name__ == "__main__":
     graph_names = ["fb15k237", "WN18RR", "YAGO3_10"]
     processed_path = Path("../DATA/processed")
     hold_out_fold = "hold_out_"
-    files_suffix = ["train", "valid"]
+    files_suffix = ["train", "valid", "test"]
     split_k = 10
+    hit_range = 10
     for name in graph_names:
         for hold_out_k in range(split_k):
             hold_out_fold_path = processed_path / name / (hold_out_fold + str(hold_out_k))
@@ -25,10 +26,32 @@ if __name__ == "__main__":
             # 载入可能的超参数
             # alpha_grid = [0.1, 0.2, 0.25, 0.3, 0.35]
             alpha_grid = [0.2]
-            for alpha in alpha_grid:
+            valid_results = []
+            for id, alpha in enumerate(alpha_grid):
                 one_hold_out_experiment = PRATrain(query_graph=graph_train,
                                                    neg_pairs_path=processed_path / name / "fb15k237.neg.graph",
                                                    meta_path_file=hold_out_fold_path / "train.MetaPaths",
                                                    hold_out_path=hold_out_fold_path,
                                                    hyper_param=alpha)
                 one_hold_out_experiment.train_this_hold_out()
+                valid_experiment = Validation(model_pt=one_hold_out_experiment.model_pt,
+                                              query_graph_pt=graph_train,
+                                              predict_graph_pt=graph_valid,
+                                              hit_range=hit_range)
+                result_tuple = valid_experiment.tail_predict()
+                print(f"Validating hyper-parameter [{id/len(alpha_grid)}]: "
+                      f"\thit@{hit_range}'s accuracy; MR; MRR: {result_tuple}.")
+                valid_results.append((id, result_tuple))
+            test_file_name = name + "." + str(hold_out_k) + "." + files_suffix[2] + "." + "graph"
+            graph_test = ProcessedGraphManager(file_path=hold_out_fold_path / test_file_name,
+                                               if_add_reverse_relation=False)
+            test_experiment = Test(query_graph_pt=graph_train,
+                                   predict_graph_pt=graph_test,
+                                   hit_range=hit_range)
+            hyper_param_id, _ = test_experiment.find_best_results(valid_results)
+            train_valid_experiment = PRATrain(query_graph=graph_train,
+                                              neg_pairs_path=processed_path / name / "fb15k237.neg.graph",
+                                              meta_path_file=hold_out_fold_path / "train.MetaPaths",
+                                              hold_out_path=hold_out_fold_path,
+                                              hyper_param=alpha_grid[hyper_param_id])
+            train_valid_experiment.load_model_from_file()

--- a/mhyao_src/PRAModel.py
+++ b/mhyao_src/PRAModel.py
@@ -1,12 +1,39 @@
 import torch.nn as nn
 import torch
+from mhyao_src.GraphManager import ProcessedGraphManager
+from temp.GetFeature import GetFeature
+from temp.data_utils import PRAData
+from torch.utils.data import DataLoader
 
 
 class LogisticRegression(nn.Module):
-    def __init__(self, input_size, num_classes):
+    def __init__(self,
+                 input_size,
+                 num_classes,
+                 query_graph_pt: ProcessedGraphManager = None):
         super(LogisticRegression, self).__init__()
         self.linear = nn.Linear(input_size, num_classes)
+        self.query_graph_pt = query_graph_pt
 
     def forward(self, x):
         output = self.linear(x)
         return torch.sigmoid(output)
+
+    def rank_score(self,
+                   head_mid: str,
+                   relation: str,
+                   tail_mid: str):
+        entity_pairs_1 = [head_mid, tail_mid, 1]
+        feature = GetFeature(tuple_data=self.query_graph_pt.fact_list,
+                             entity_pairs=entity_pairs_1,
+                             metapath=self.query_graph_pt.relation_meta_paths[relation])
+        data_feature = feature.get_probs()
+        metapath_len = len(self.query_graph_pt.relation_meta_paths[relation])
+        batch_size = 1
+        pra_data = PRAData(data_feature_dict=data_feature,
+                           metapath_len=metapath_len)
+        train_loader = DataLoader(pra_data, batch_size=batch_size)
+        results = []
+        for i, (path_feature, label) in enumerate(train_loader):
+            results.append(self.forward(path_feature))
+        return results[0]


### PR DESCRIPTION
在LaunchHoldOutTest.py中添加了整个训练pipeline,但是还留有load_model_from_file等方法没写；
在PRAModel.py中为logisticRegression类添加了rank_score方法.但是如何将多个关系的模型集中起来,还没想清楚,考虑这个问题是因为validation和test实验类的tail_predict方法只会有一个模型指针,而不会有一堆模型指针；
在Experiments.py中的Test类中添加了筛选最优结果的函数find_best_results;在PRATrain类中添加了self.model_pt的属性,以及load_model_from_file的方法,这个方法还是得考虑前面提到的关于模型指针数量的问题.